### PR TITLE
refactor: introduce requireRole authorization guard (#187)

### DIFF
--- a/__tests__/lib/authz.test.js
+++ b/__tests__/lib/authz.test.js
@@ -1,0 +1,45 @@
+import { requireRole, AuthzError } from "@/lib/authz";
+
+describe("requireRole", () => {
+  it("throws AuthzError when user role is not in allowed list", () => {
+    const user = { role: "EDITOR" };
+    expect(() => requireRole("ADMIN", "SUPER_ADMIN")(user)).toThrow(AuthzError);
+  });
+
+  it("throws with the standard forbidden message", () => {
+    const user = { role: "EDITOR" };
+    expect(() => requireRole("ADMIN")(user)).toThrow("Operation not permitted.");
+  });
+
+  it("does not throw when user has an allowed role", () => {
+    const admin = { role: "ADMIN" };
+    expect(() => requireRole("ADMIN", "SUPER_ADMIN")(admin)).not.toThrow();
+  });
+
+  it("does not throw for SUPER_ADMIN when both roles are allowed", () => {
+    const superAdmin = { role: "SUPER_ADMIN" };
+    expect(() => requireRole("ADMIN", "SUPER_ADMIN")(superAdmin)).not.toThrow();
+  });
+
+  it("throws for an unknown role", () => {
+    const user = { role: "UNKNOWN" };
+    expect(() => requireRole("ADMIN")(user)).toThrow(AuthzError);
+  });
+});
+
+describe("AuthzError", () => {
+  it("is an instance of Error", () => {
+    const err = new AuthzError();
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("carries status 403", () => {
+    const err = new AuthzError();
+    expect(err.status).toBe(403);
+  });
+
+  it("carries the default message", () => {
+    const err = new AuthzError();
+    expect(err.message).toBe("Operation not permitted.");
+  });
+});

--- a/lib/authz.js
+++ b/lib/authz.js
@@ -1,0 +1,24 @@
+export class AuthzError extends Error {
+  constructor(message = "Operation not permitted.") {
+    super(message);
+    this.name = "AuthzError";
+    this.status = 403;
+  }
+}
+
+export function requireRole(...allowedRoles) {
+  return function (user) {
+    if (!allowedRoles.includes(user.role)) {
+      throw new AuthzError();
+    }
+  };
+}
+
+// eslint-disable-next-line no-unused-vars
+export function onError(err, _req, res, _next) {
+  if (err instanceof AuthzError) {
+    return res.status(403).json({ message: err.message });
+  }
+  console.error(err);
+  return res.status(500).json({ message: err.message ?? "Internal server error" });
+}

--- a/pages/api/cheques/index.js
+++ b/pages/api/cheques/index.js
@@ -3,6 +3,7 @@ import nextConnect from "next-connect";
 
 import db from "@/lib/postgres";
 import { auth } from "@/middlewares/auth";
+import { requireRole, onError } from "@/lib/authz";
 import { DEFAULT_ROWS_LIMIT } from "@/utils/api.util";
 import TenantContext from "@/lib/tenant-context";
 
@@ -43,10 +44,7 @@ const updateChequeStatus = async (req, res) => {
   if (error && error && Object.keys(error).length) {
     return res.status(400).send({ message: error.toString() });
   }
-  if (!["ADMIN", "SUPER_ADMIN"].includes(req.user.role)) {
-    return res.status(400).send({ message: "Operation not permitted." });
-  }
-
+  requireRole("ADMIN", "SUPER_ADMIN")(req.user);
   try {
     await dbConnect();
     const organizationId = TenantContext.assertGet();
@@ -67,4 +65,4 @@ const updateChequeStatus = async (req, res) => {
   }
 };
 
-export default nextConnect().use(auth).get(getAllCheques).put(updateChequeStatus);
+export default nextConnect({ onError }).use(auth).get(getAllCheques).put(updateChequeStatus);

--- a/pages/api/org/invite.js
+++ b/pages/api/org/invite.js
@@ -4,6 +4,7 @@ import { UniqueConstraintError } from "sequelize";
 
 import db from "@/lib/postgres";
 import { auth } from "@/middlewares/auth";
+import { requireRole, onError } from "@/lib/authz";
 import TenantContext from "@/lib/tenant-context";
 import { buildInviteUrl, createInviteToken, getInviteExpiry, hashInviteToken } from "@/lib/org-onboarding";
 import { sendInviteEmail } from "@/lib/invite-email";
@@ -16,10 +17,7 @@ const apiSchema = Joi.object({
 });
 
 export const inviteUser = async (req, res) => {
-  if (!["ADMIN", "SUPER_ADMIN"].includes(req.user.role)) {
-    return res.status(403).send({ message: "Operation not permitted." });
-  }
-
+  requireRole("ADMIN", "SUPER_ADMIN")(req.user);
   const { error, value } = apiSchema.validate(req.body);
   if (error && Object.keys(error).length) {
     return res.status(400).send({ message: error.toString() });
@@ -102,4 +100,4 @@ export const inviteUser = async (req, res) => {
   }
 };
 
-export default nextConnect().use(auth).post(inviteUser);
+export default nextConnect({ onError }).use(auth).post(inviteUser);

--- a/pages/api/org/invite/[id].js
+++ b/pages/api/org/invite/[id].js
@@ -4,6 +4,7 @@ import { UniqueConstraintError } from "sequelize";
 
 import db from "@/lib/postgres";
 import { auth } from "@/middlewares/auth";
+import { requireRole, onError } from "@/lib/authz";
 import TenantContext from "@/lib/tenant-context";
 import { buildInviteUrl, createInviteToken, getInviteExpiry, hashInviteToken } from "@/lib/org-onboarding";
 import { sendInviteEmail } from "@/lib/invite-email";
@@ -14,10 +15,7 @@ const apiSchema = Joi.object({
 });
 
 export const resendInvite = async (req, res) => {
-  if (!["ADMIN", "SUPER_ADMIN"].includes(req.user.role)) {
-    return res.status(403).send({ message: "Operation not permitted." });
-  }
-
+  requireRole("ADMIN", "SUPER_ADMIN")(req.user);
   const { error, value } = apiSchema.validate({ id: req.query.id, sendEmail: req.body?.sendEmail });
   if (error && Object.keys(error).length) {
     return res.status(400).send({ message: error.toString() });
@@ -90,4 +88,4 @@ export const resendInvite = async (req, res) => {
   }
 };
 
-export default nextConnect().use(auth).post(resendInvite);
+export default nextConnect({ onError }).use(auth).post(resendInvite);

--- a/pages/api/purchase/approve/[id].js
+++ b/pages/api/purchase/approve/[id].js
@@ -3,6 +3,7 @@ import nextConnect from "next-connect";
 
 import db from "@/lib/postgres";
 import { auth } from "@/middlewares/auth";
+import { requireRole, AuthzError, onError } from "@/lib/authz";
 import { SPEND_TYPE, STATUS } from "@/utils/api.util";
 import { balanceQuery } from "@/utils/query.utils";
 import TenantContext from "@/lib/tenant-context";
@@ -36,8 +37,11 @@ const handler = async (req, res) => {
 };
 
 const approvePurchaseOrder = async (id, user) => {
-  if (!["ADMIN", "SUPER_ADMIN"].includes(user.role)) {
-    return { status: 403, body: { message: "Operation not permitted." } };
+  try {
+    requireRole("ADMIN", "SUPER_ADMIN")(user);
+  } catch (err) {
+    if (err instanceof AuthzError) return { status: err.status, body: { message: err.message } };
+    throw err;
   }
 
   let t;
@@ -270,4 +274,4 @@ const hydrateRevisedProducts = (revisionProducts, originalProducts, usesDeltaVal
 };
 
 export { handler, approvePurchaseOrder, updateInventory, updateLedger };
-export default nextConnect().use(auth).put(handler);
+export default nextConnect({ onError }).use(auth).put(handler);

--- a/pages/api/purchase/cancel/[id].js
+++ b/pages/api/purchase/cancel/[id].js
@@ -3,6 +3,7 @@ import nextConnect from "next-connect";
 
 import db from "@/lib/postgres";
 import { auth } from "@/middlewares/auth";
+import { requireRole, onError } from "@/lib/authz";
 import { STATUS } from "@/utils/api.util";
 import TenantContext from "@/lib/tenant-context";
 
@@ -19,9 +20,7 @@ const cancelPurchaseOrder = async (req, res) => {
   if (error && error && Object.keys(error).length) {
     return res.status(400).send({ message: error.toString() });
   }
-  if (!["ADMIN", "SUPER_ADMIN"].includes(req.user.role)) {
-    return res.status(400).send({ message: "Operation not permitted." });
-  }
+  requireRole("ADMIN", "SUPER_ADMIN")(req.user);
   try {
     await db.dbConnect();
     const organizationId = TenantContext.assertGet();
@@ -40,4 +39,4 @@ const cancelPurchaseOrder = async (req, res) => {
   }
 };
 
-export default nextConnect().use(auth).put(cancelPurchaseOrder);
+export default nextConnect({ onError }).use(auth).put(cancelPurchaseOrder);

--- a/pages/api/sales/approve/[id].js
+++ b/pages/api/sales/approve/[id].js
@@ -3,6 +3,7 @@ import nextConnect from "next-connect";
 
 import db from "@/lib/postgres";
 import { auth } from "@/middlewares/auth";
+import { requireRole, onError } from "@/lib/authz";
 import { STATUS, SPEND_TYPE } from "@/utils/api.util";
 import { balanceQuery } from "@/utils/query.utils";
 import { applyTenantToTransaction, createTenantTransaction } from "@/lib/tenant-transaction";
@@ -20,9 +21,7 @@ const handler = async (req, res) => {
   if (error && Object.keys(error).length) {
     return res.status(400).send({ message: error.toString() });
   }
-  if (!["ADMIN", "SUPER_ADMIN"].includes(req.user.role)) {
-    return res.status(400).send({ message: "Operation not permitted." });
-  }
+  requireRole("ADMIN", "SUPER_ADMIN")(req.user);
   try {
     const { id } = value;
     const { sale, ledger, inventory } = await approveSaleOrder(id);
@@ -134,4 +133,4 @@ const getLockOption = (transaction, model) => {
   return model ? { lock: { level: transaction.LOCK.UPDATE, of: model } } : { lock: transaction.LOCK.UPDATE };
 };
 
-export default nextConnect().use(auth).put(handler);
+export default nextConnect({ onError }).use(auth).put(handler);

--- a/pages/api/sales/cancel/[id].js
+++ b/pages/api/sales/cancel/[id].js
@@ -3,6 +3,7 @@ import nextConnect from "next-connect";
 
 import db from "@/lib/postgres";
 import { auth } from "@/middlewares/auth";
+import { requireRole, onError } from "@/lib/authz";
 import { STATUS } from "@/utils/api.util";
 import TenantContext from "@/lib/tenant-context";
 
@@ -19,9 +20,7 @@ const cancelSaleOrder = async (req, res) => {
   if (error && error && Object.keys(error).length) {
     return res.status(400).send({ message: error.toString() });
   }
-  if (!["ADMIN", "SUPER_ADMIN"].includes(req.user.role)) {
-    return res.status(400).send({ message: "Operation not permitted." });
-  }
+  requireRole("ADMIN", "SUPER_ADMIN")(req.user);
   try {
     await db.dbConnect();
     const organizationId = TenantContext.assertGet();
@@ -40,4 +39,4 @@ const cancelSaleOrder = async (req, res) => {
   }
 };
 
-export default nextConnect().use(auth).put(cancelSaleOrder);
+export default nextConnect({ onError }).use(auth).put(cancelSaleOrder);

--- a/pages/api/sales/returns/index.js
+++ b/pages/api/sales/returns/index.js
@@ -98,10 +98,7 @@ const createSaleReturn = async (req, res) => {
     return res.status(400).send({ message: error.toString() });
   }
 
-  if (!["ADMIN", "SUPER_ADMIN"].includes(req.user.role)) {
-    return res.status(400).send({ message: "Operation not permitted." });
-  }
-
+  requireRole("ADMIN", "SUPER_ADMIN")(req.user);
   try {
     await db.dbConnect();
     const tenantTransaction = await createTenantTransaction();
@@ -238,4 +235,4 @@ const getLockOption = (transaction, model) => {
   return model ? { lock: { level: transaction.LOCK.UPDATE, of: model } } : { lock: transaction.LOCK.UPDATE };
 };
 
-export default nextConnect().use(auth).post(createSaleReturn).get(getAllSaleReturns);
+export default nextConnect({ onError }).use(auth).post(createSaleReturn).get(getAllSaleReturns);

--- a/pages/api/user/index.js
+++ b/pages/api/user/index.js
@@ -2,15 +2,13 @@ import nextConnect from "next-connect";
 
 import db from "@/lib/postgres";
 import { auth } from "@/middlewares/auth";
+import { requireRole, onError } from "@/lib/authz";
 import { DEFAULT_ROWS_LIMIT } from "@/utils/api.util";
 import TenantContext from "@/lib/tenant-context";
 
 export const getAllUsers = async (req, res) => {
   console.log("get all users Request Start");
-  if (!["ADMIN", "SUPER_ADMIN"].includes(req.user.role)) {
-    return res.status(403).send({ message: "Operation not permitted." });
-  }
-
+  requireRole("ADMIN", "SUPER_ADMIN")(req.user);
   const { limit, offset } = req.query;
   const pagination = {};
   pagination.limit = limit ? limit : DEFAULT_ROWS_LIMIT;
@@ -34,4 +32,4 @@ export const getAllUsers = async (req, res) => {
   }
 };
 
-export default nextConnect().use(auth).get(getAllUsers);
+export default nextConnect({ onError }).use(auth).get(getAllUsers);


### PR DESCRIPTION
Replace 9 inline ["ADMIN","SUPER_ADMIN"].includes(user.role) checks with requireRole() from lib/authz.js. All affected routes now return a consistent 403 via the shared onError handler on nextConnect.