### PR TITLE
fix: add missing uuid to bootstrap-super-admin.js inserts

### DIFF
--- a/scripts/bootstrap-super-admin.js
+++ b/scripts/bootstrap-super-admin.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const crypto = require("crypto");
 const bcrypt = require("bcrypt");
 const Sequelize = require("sequelize");
 
@@ -22,8 +23,8 @@ async function run() {
 
     const [organization] = await sequelize.query(
       `
-        INSERT INTO organizations (name, slug, plan, status, "maxUsers", "createdAt", "updatedAt")
-        VALUES ('System', 'system', 'ENTERPRISE', 'ACTIVE', 100, NOW(), NOW())
+        INSERT INTO organizations (uuid, name, slug, plan, status, "maxUsers", "createdAt", "updatedAt")
+        VALUES (:uuid, 'System', 'system', 'ENTERPRISE', 'ACTIVE', 100, NOW(), NOW())
         ON CONFLICT (slug)
         DO UPDATE SET
           name = EXCLUDED.name,
@@ -33,7 +34,10 @@ async function run() {
           "updatedAt" = NOW()
         RETURNING id, uuid, name, slug;
       `,
-      { type: Sequelize.QueryTypes.SELECT }
+      {
+        replacements: { uuid: crypto.randomUUID() },
+        type: Sequelize.QueryTypes.SELECT,
+      }
     );
 
     const passwordHash = await bcrypt.hash(process.env.SUPER_ADMIN_PASSWORD, 10);
@@ -41,6 +45,7 @@ async function run() {
     const [user] = await sequelize.query(
       `
         INSERT INTO users (
+          uuid,
           "firstName",
           "lastName",
           email,
@@ -53,6 +58,7 @@ async function run() {
           "updatedAt"
         )
         VALUES (
+          :uuid,
           :firstName,
           :lastName,
           :email,
@@ -78,6 +84,7 @@ async function run() {
       `,
       {
         replacements: {
+          uuid: crypto.randomUUID(),
           firstName: process.env.SUPER_ADMIN_FIRST_NAME.toLowerCase(),
           lastName: process.env.SUPER_ADMIN_LAST_NAME.toLowerCase(),
           email: process.env.SUPER_ADMIN_EMAIL.toLowerCase(),


### PR DESCRIPTION
## Summary

- `organizations.uuid` and `users.uuid` are `NOT NULL` with no Postgres-level default — `defaultValue: DataTypes.UUIDV4` in the Sequelize model/migration only applies via `Model.create()`, it never becomes a DDL `DEFAULT` from `queryInterface.createTable`. Confirmed via `information_schema.columns` / `pg_attrdef` against the local dev DB (both `column_default` and `pg_get_expr(adbin, adrelid)` are `null`).
- `scripts/bootstrap-super-admin.js`'s two raw `INSERT` statements omitted `uuid` entirely, so running this script fresh against a real database crashed with `null value in column "uuid" violates not-null constraint`.
- Fix adds `uuid` (via `crypto.randomUUID()`) to both `INSERT` column lists/values. The `uuid` is intentionally left out of both `ON CONFLICT ... DO UPDATE SET` clauses so re-running the script never changes an existing row's uuid.
- Audited the rest of `scripts/*.js` for the same pattern: `verify-rls.js`, `verify-security.js`, `verify-tenant-backfill.js` don't do raw `INSERT`s, and `run-migrations.js`'s only `INSERT` targets `SequelizeMeta` (no `uuid` column) — no other scripts are affected.

## Test plan

- [x] `npx eslint scripts/bootstrap-super-admin.js` / `npx prettier --check` — clean
- [x] Ran the script against local dev Postgres with test env vars — previously would have failed with the not-null violation on `organizations`; now completes and prints both generated uuids
- [x] Ran it a second time with a different password — confirmed the `ON CONFLICT` path updates the password but the organization's and user's `id`/`uuid` stay identical to the first run
- [x] Cleaned up the test rows created during verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)