### PR TITLE
fix: sales returns page crashes with 500 (missing onError/requireRole import)

### DIFF
--- a/__tests__/api/sales/returns.test.js
+++ b/__tests__/api/sales/returns.test.js
@@ -1,0 +1,23 @@
+// pages/api/sales/returns/index.js builds its default export via
+// nextConnect({ onError }).use(auth).post(createSaleReturn).get(getAllSaleReturns) —
+// onError/requireRole were previously referenced without being imported from
+// @/lib/authz, causing a ReferenceError at module-evaluation time (every request
+// to this route crashed with a 500 before even reaching auth/validation).
+// createSaleReturn/getAllSaleReturns aren't exported individually, so importing
+// the default export here is what actually exercises — and would catch a
+// regression of — that line.
+jest.mock("@/lib/postgres", () => ({
+  dbConnect: jest.fn(),
+  SaleReturn: { findAndCountAll: jest.fn() },
+  Customer: {},
+  Sale: {},
+}));
+
+describe("sale returns API module", () => {
+  it("builds its default next-connect handler without throwing", () => {
+    expect(() => require("@/pages/api/sales/returns/index")).not.toThrow();
+
+    const handler = require("@/pages/api/sales/returns/index").default;
+    expect(typeof handler).toBe("function");
+  });
+});

--- a/pages/api/sales/returns/index.js
+++ b/pages/api/sales/returns/index.js
@@ -4,6 +4,7 @@ import nextConnect from "next-connect";
 import db from "@/lib/postgres";
 import { createLedgerPayment } from "@/lib/ledger";
 import { auth } from "@/middlewares/auth";
+import { requireRole, onError } from "@/lib/authz";
 import { PAYMENT_TYPE, SPEND_TYPE, STATUS } from "@/utils/api.util";
 import { getReturnedQuantityMap, getSaleReturnItemKey } from "@/utils/saleReturn.util";
 import TenantContext from "@/lib/tenant-context";


### PR DESCRIPTION
## Summary

- `pages/api/sales/returns/index.js` referenced `onError` and `requireRole` without importing them from `@/lib/authz` — every other role-gated route imports this pair (e.g. `pages/api/cheques/index.js`).
- `onError` is used directly in the top-level `nextConnect({ onError })` call, so this was a `ReferenceError` at **module-evaluation time**: every request to `GET`/`POST /api/sales/returns` crashed with a 500, before auth or validation even ran.
- Introduced in 0df2c7d ("refactor: introduce requireRole authorization guard"), already on `development`.
- Reported live: clicking "Sale Returns" in the dashboard nav threw `GET /api/sales/returns?limit=50&offset=0 500` with `ReferenceError: onError is not defined at pages/api/sales/returns/index.js:238:30`.

## Fix

One-line import addition:
```js
import { requireRole, onError } from "@/lib/authz";
```

## Test plan

- [x] Reproduced the exact reported error by temporarily stashing the fix and running the new test — fails with `onError is not defined` on the old code
- [x] Added `__tests__/api/sales/returns.test.js` — imports the module's default export directly (the route's handlers aren't individually exported, so this is what actually exercises the broken line) and asserts it doesn't throw. Confirmed this test fails without the fix and passes with it.
- [x] `npx eslint` clean on both changed files
- [x] Full `npx jest` suite — no new failures (1 pre-existing unrelated failure in `navigation-config.test.js`, present on `development` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)