### PR TITLE
fix: negative balances render as -,139.95 instead of -139.95

### DIFF
--- a/__tests__/utils/comaSeparatedValues.util.test.js
+++ b/__tests__/utils/comaSeparatedValues.util.test.js
@@ -1,7 +1,7 @@
 import { comaSeparatedValues } from "@/utils/comaSeparatedValues";
 
 describe("comaSeparatedValues", () => {
-  it("formats positive values with Indian-style digit grouping", () => {
+  it("formats positive values with Pakistani-style digit grouping", () => {
     expect(comaSeparatedValues(139.95)).toBe("139.95");
     expect(comaSeparatedValues(1139.95)).toBe("1,139.95");
     expect(comaSeparatedValues(1234567.5)).toBe("12,34,567.50");

--- a/__tests__/utils/comaSeparatedValues.util.test.js
+++ b/__tests__/utils/comaSeparatedValues.util.test.js
@@ -1,0 +1,29 @@
+import { comaSeparatedValues } from "@/utils/comaSeparatedValues";
+
+describe("comaSeparatedValues", () => {
+  it("formats positive values with Indian-style digit grouping", () => {
+    expect(comaSeparatedValues(139.95)).toBe("139.95");
+    expect(comaSeparatedValues(1139.95)).toBe("1,139.95");
+    expect(comaSeparatedValues(1234567.5)).toBe("12,34,567.50");
+  });
+
+  it("formats negative values without inserting a comma next to the sign", () => {
+    expect(comaSeparatedValues(-139.95)).toBe("-139.95");
+    expect(comaSeparatedValues(-1139.95)).toBe("-1,139.95");
+    expect(comaSeparatedValues(-1234567.5)).toBe("-12,34,567.50");
+  });
+
+  it("handles values under 100 and zero", () => {
+    expect(comaSeparatedValues(9.5)).toBe("9.50");
+    expect(comaSeparatedValues(-9.5)).toBe("-9.50");
+    expect(comaSeparatedValues(0)).toBe("0.00");
+  });
+
+  it("accepts numeric strings", () => {
+    expect(comaSeparatedValues("-139.95")).toBe("-139.95");
+  });
+
+  it("returns the original value unchanged for non-numeric input", () => {
+    expect(comaSeparatedValues("N/A")).toBe("N/A");
+  });
+});

--- a/utils/comaSeparatedValues.js
+++ b/utils/comaSeparatedValues.js
@@ -5,7 +5,12 @@ export const comaSeparatedValues = (value) => {
     return value;
   }
 
-  const fixedValue = numberValue.toFixed(2);
+  // Group digits on the absolute value, then reapply the sign — otherwise the
+  // "-" ends up inside integerPart.slice(0, -3) and gets treated as a leading
+  // digit group, producing "-,139.95" instead of "-139.95" for any negative
+  // number whose integer part is exactly 3 digits.
+  const isNegative = numberValue < 0;
+  const fixedValue = Math.abs(numberValue).toFixed(2);
   const [integerPart, decimalPart] = fixedValue.split(".");
 
   const lastThreeDigits = integerPart.slice(-3);
@@ -14,5 +19,6 @@ export const comaSeparatedValues = (value) => {
     otherDigits.length > 0
       ? `${otherDigits.replace(/\B(?=(\d{2})+(?!\d))/g, ",")},${lastThreeDigits}`
       : lastThreeDigits;
-  return decimalPart ? `${formattedInteger}.${decimalPart}` : formattedInteger;
+  const signedInteger = isNegative ? `-${formattedInteger}` : formattedInteger;
+  return decimalPart ? `${signedInteger}.${decimalPart}` : signedInteger;
 };


### PR DESCRIPTION
## Summary

- `utils/comaSeparatedValues.js`'s digit-grouping logic sliced the last 3 characters off the string form of the integer part (including the "-" sign for negative numbers) to build the last group, then treated whatever was left (`slice(0, -3)`) as "more digits to comma-separate."
- For any negative number whose integer part has exactly 3 digits (e.g. `-139.95`), that leftover is just the `"-"` sign — non-empty, so the function unconditionally inserted a comma before the last group: `-` + `,` + `139` + `.95` = `-,139.95`.
- Reported live: a customer ledger card showed `Total Balance -,139.95` for a balance of `-139.95`.

## Fix

Strip the sign before grouping digits, then reapply it to the formatted result — the grouping logic now only ever sees digits.

## Test plan

- [x] Added `__tests__/utils/comaSeparatedValues.util.test.js` covering positive/negative values above and below 1000, zero, numeric-string input, and non-numeric passthrough
- [x] Confirmed the new tests fail with the exact reported `-,139.95` output on the old code (via a temporary revert) and pass with the fix
- [x] `npx eslint` / `npx prettier --check` clean
- [x] Full `npx jest` suite — no new failures (1 pre-existing unrelated failure in `navigation-config.test.js`)

This affects every page that renders a signed amount through `comaSeparatedValues` — ledger detail/list, sales/purchase reports, customer/company reports, PDF/CSV ledger exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)