### PR TITLE
fix: bump inventories_id_seq after explicit-id Inventory creates

### DIFF
--- a/__tests__/api/purchase/approve.test.js
+++ b/__tests__/api/purchase/approve.test.js
@@ -400,6 +400,27 @@ describe("updateInventory", () => {
     expect(db.Inventory.create).toHaveBeenCalled();
   });
 
+  it("bumps inventories_id_seq past a newly created inventory's explicit id, so the sequence never falls behind", async () => {
+    db.Inventory.findOne.mockResolvedValue(null);
+    db.Inventory.create.mockResolvedValue({ id: 123 });
+
+    await TenantContext.run(23, async () => updateInventory([product], 1, transaction));
+
+    expect(db.sequelize.query).toHaveBeenCalledWith(expect.stringContaining("setval"), {
+      replacements: { id: 123 },
+      transaction,
+    });
+  });
+
+  it("does not touch the sequence when reusing an existing inventory row", async () => {
+    const mockInventory = { increment: jest.fn(), update: jest.fn(), baleWeightKgs: 0, baleWeightLbs: 0 };
+    db.Inventory.findOne.mockResolvedValue(mockInventory);
+
+    await TenantContext.run(23, async () => updateInventory([product], 1, transaction));
+
+    expect(db.sequelize.query).not.toHaveBeenCalledWith(expect.stringContaining("setval"), expect.any(Object));
+  });
+
   it("should update inventory with null weights", async () => {
     const mockInv = {
       increment: jest.fn(),

--- a/__tests__/api/sales/returns.test.js
+++ b/__tests__/api/sales/returns.test.js
@@ -1,23 +1,61 @@
+import TenantContext from "@/lib/tenant-context";
+import db from "@/lib/postgres";
 // pages/api/sales/returns/index.js builds its default export via
 // nextConnect({ onError }).use(auth).post(createSaleReturn).get(getAllSaleReturns) —
 // onError/requireRole were previously referenced without being imported from
 // @/lib/authz, causing a ReferenceError at module-evaluation time (every request
 // to this route crashed with a 500 before even reaching auth/validation).
-// createSaleReturn/getAllSaleReturns aren't exported individually, so importing
-// the default export here is what actually exercises — and would catch a
-// regression of — that line.
+// Importing the default export here is what actually exercises — and would
+// catch a regression of — that line.
+import saleReturnsHandler, { updateInventoryForReturn } from "@/pages/api/sales/returns/index";
+
 jest.mock("@/lib/postgres", () => ({
   dbConnect: jest.fn(),
+  sequelize: { query: jest.fn().mockResolvedValue() },
   SaleReturn: { findAndCountAll: jest.fn() },
+  Inventory: { findOne: jest.fn(), create: jest.fn() },
   Customer: {},
   Sale: {},
 }));
 
 describe("sale returns API module", () => {
   it("builds its default next-connect handler without throwing", () => {
-    expect(() => require("@/pages/api/sales/returns/index")).not.toThrow();
+    expect(typeof saleReturnsHandler).toBe("function");
+  });
+});
 
-    const handler = require("@/pages/api/sales/returns/index").default;
-    expect(typeof handler).toBe("function");
+describe("updateInventoryForReturn", () => {
+  const transaction = {};
+  const product = { id: 1, companyId: 1, noOfBales: 5, baleWeightKgs: 100, baleWeightLbs: 200, itemName: "shirt" };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("bumps inventories_id_seq past a newly created inventory's explicit id, so the sequence never falls behind", async () => {
+    db.Inventory.findOne.mockResolvedValue(null);
+    db.Inventory.create.mockResolvedValue({ id: 456 });
+
+    await TenantContext.run(23, async () => updateInventoryForReturn([product], transaction));
+
+    expect(db.sequelize.query).toHaveBeenCalledWith(expect.stringContaining("setval"), {
+      replacements: { id: 456 },
+      transaction,
+    });
+  });
+
+  it("does not touch the sequence when reusing an existing inventory row", async () => {
+    const mockInventory = {
+      increment: jest.fn(),
+      update: jest.fn(),
+      reload: jest.fn(),
+      baleWeightKgs: 0,
+      baleWeightLbs: 0,
+    };
+    db.Inventory.findOne.mockResolvedValue(mockInventory);
+
+    await TenantContext.run(23, async () => updateInventoryForReturn([product], transaction));
+
+    expect(db.sequelize.query).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/lib/inventory.test.js
+++ b/__tests__/lib/inventory.test.js
@@ -1,0 +1,30 @@
+import { bumpInventorySequence } from "@/lib/inventory";
+import db from "@/lib/postgres";
+
+jest.mock("@/lib/postgres", () => ({
+  __esModule: true,
+  default: {
+    sequelize: {
+      query: jest.fn(),
+    },
+  },
+}));
+
+describe("bumpInventorySequence", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("runs a setval query bounded by GREATEST so it never moves the sequence backward", async () => {
+    const transaction = {};
+
+    await bumpInventorySequence(123, transaction);
+
+    expect(db.sequelize.query).toHaveBeenCalledTimes(1);
+    const [sql, options] = db.sequelize.query.mock.calls[0];
+    expect(sql).toContain("setval");
+    expect(sql).toContain("GREATEST");
+    expect(sql).toContain("inventories_id_seq");
+    expect(options).toEqual({ replacements: { id: 123 }, transaction });
+  });
+});

--- a/docs/inventory-sequence-drift-incident.md
+++ b/docs/inventory-sequence-drift-incident.md
@@ -1,0 +1,108 @@
+# Incident: `inventories_id_seq` silently drifting behind real data
+
+**Date found:** 2026-07-02
+**Severity:** High — a live production crash waiting to happen, already causing app instability elsewhere
+**Status:** Fixed in [PR #206](https://github.com/hammadtariq/inventory-system-nextjs/pull/206)
+
+## TL;DR
+
+Every time the app approved a purchase (or processed a sale return) for an item
+that had never been stocked before, it created the new `Inventory` row with a
+hand-picked ID instead of letting the database assign one. The database's
+internal "next ID to use" counter never found out about those hand-picked IDs,
+so it kept falling further behind reality. Eventually the counter would hand
+out an ID that was already taken, and the request would crash outright. This
+had already happened once in production (a different table, same root cause
+pattern) and was measurably 645 IDs behind on the `inventories` table by the
+time it was found — meaning it was actively happening in normal day-to-day use,
+not a one-off fluke.
+
+## How this was found
+
+While restoring a database backup to fix an unrelated problem, every table's
+"next ID" counter was checked against the real highest ID actually present in
+each table. Two tables were behind:
+
+| Table         | Counter said next ID is... | Real highest ID in the table | Gap                                                                                                                  |
+| ------------- | -------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `users`       | 1                          | 6                            | 5 (from an earlier, separate issue — see [PR #201](https://github.com/hammadtariq/inventory-system-nextjs/pull/201)) |
+| `inventories` | 526                        | 1171                         | **645**                                                                                                              |
+
+The `inventories` gap of 645 was the red flag — that's not something a one-time
+data import could produce (the import only had ~1,100 rows total). It could
+only come from the app itself repeatedly creating rows with a hand-picked ID
+during normal use, over what looks like a long stretch of real usage.
+
+## Why this happens
+
+Every database table here that has an auto-incrementing ID column has an
+internal counter (Postgres calls it a "sequence") that hands out the next
+number whenever a new row is inserted _without_ specifying an ID. That's how
+IDs normally get assigned — you never think about it because it just works.
+
+But two places in the code explicitly set the ID by hand instead of letting
+the counter do it:
+
+- `pages/api/purchase/approve/[id].js` — when a purchase order is approved and
+  one of the purchased items has never been stocked before, the code creates
+  its `Inventory` row using **the same ID as the purchased item itself**
+  (deliberately — so that a later screen can look the stock up by that same
+  ID). This is intentional design, not a mistake.
+- `pages/api/sales/returns/index.js` — does the identical thing when
+  processing a return for an item that isn't currently in stock.
+
+The problem: when you insert a row with a hand-picked ID, Postgres's counter
+has no idea that ID was just used. It keeps counting from wherever it last
+left off. So the counter and the real data quietly diverge, a little more
+every time this code path runs.
+
+## Why this is critical
+
+Once the counter's number is _behind_ the real highest ID in the table, it is
+only a matter of time before the counter hands out a number that's already
+taken by one of those hand-picked-ID rows. When that happens, the database
+rejects the insert with a "this ID is already in use" error, and the request
+that triggered it — some completely unrelated, perfectly normal action, like
+approving a purchase or creating a new inventory item the regular way — fails
+outright with a server error.
+
+This exact failure mode already happened once in production, on the `users`
+table, while seeding a demo organization (see PR #201's follow-up work): a
+brand-new user couldn't be created because the counter tried to hand out an ID
+that was already taken. That was a nuisance, not a disaster, because user
+creation is rare. The `inventories` table is a different story — new items get
+added to inventory constantly as part of normal, everyday purchase approvals.
+A collision there would surface as a random, hard-to-explain 500 error on an
+otherwise completely valid purchase approval, with no clear trigger from the
+user's point of view — exactly the kind of bug that's miserable to diagnose
+after the fact because it looks intermittent and unrelated to anything the
+user actually did wrong.
+
+## The fix
+
+After either of those two code paths creates a new `Inventory` row with a
+hand-picked ID, a new one-line helper immediately tells Postgres's counter
+"make sure your next number is higher than this ID I just used." If the
+counter is already ahead, it does nothing — it only ever moves forward, never
+backward, so it can't undo any legitimate progress.
+
+This was verified three ways before merging:
+
+1. **Automated tests** that fail on the old code and pass on the fixed code
+   (proving they actually catch this specific bug, not just checking
+   something superficial).
+2. **Ran the actual database command against a real copy of the database**
+   to confirm it correctly nudges the counter forward when behind, and
+   correctly leaves it alone when it's already ahead.
+3. **The existing full test suite** still passes with no new failures.
+
+## What this doesn't fix by itself
+
+This fix stops the drift from happening _going forward_. It does not
+retroactively fix drift that may already exist on production today — that's
+what [`scripts/resync-tenant-sequences.js`](../scripts/resync-tenant-sequences.js)
+(PR #205) is for: a script you can run to check every table's counter against
+its real data and correct any that are already behind. Think of PR #206 (this
+fix) as "stop the leak" and PR #205 as "bail out the water that's already
+there." Both are worth merging; #206 is the more important of the two, since
+without it the leak just starts again.

--- a/lib/inventory.js
+++ b/lib/inventory.js
@@ -1,0 +1,21 @@
+import db from "@/lib/postgres";
+
+// Inventory rows are sometimes created with an explicit id (matching the id of
+// the Items/product they came from — see pages/api/purchase/approve/[id].js and
+// pages/api/sales/returns/index.js) instead of letting Postgres assign one via
+// inventories_id_seq. Postgres sequences don't auto-advance when a primary key
+// value is supplied explicitly, so without this call the sequence silently
+// drifts behind the real MAX(id) until a later auto-generated insert collides
+// with an already-taken id ("duplicate key value violates unique constraint
+// inventories_pkey"). GREATEST keeps this a no-op if the sequence is already
+// ahead, and reading last_value (not currval()) avoids the "currval is not yet
+// defined in this session" error on a session's first call.
+export const bumpInventorySequence = async (id, transaction) => {
+  await db.sequelize.query(
+    `SELECT setval(
+       pg_get_serial_sequence('inventories', 'id'),
+       GREATEST(:id, (SELECT last_value FROM inventories_id_seq))
+     )`,
+    { replacements: { id }, transaction }
+  );
+};

--- a/pages/api/purchase/approve/[id].js
+++ b/pages/api/purchase/approve/[id].js
@@ -8,6 +8,7 @@ import { SPEND_TYPE, STATUS } from "@/utils/api.util";
 import { balanceQuery } from "@/utils/query.utils";
 import TenantContext from "@/lib/tenant-context";
 import { createTenantTransaction } from "@/lib/tenant-transaction";
+import { bumpInventorySequence } from "@/lib/inventory";
 
 const apiSchema = Joi.object({
   id: Joi.number().required(),
@@ -146,6 +147,7 @@ const updateInventory = async (products, companyId, transaction) => {
         { ...product, companyId, onHand: noOfBales || 0, baleWeightKgs, baleWeightLbs, organizationId },
         { transaction }
       );
+      await bumpInventorySequence(inventory.id, transaction);
     }
     results.push(inventory);
   }

--- a/pages/api/sales/returns/index.js
+++ b/pages/api/sales/returns/index.js
@@ -9,6 +9,7 @@ import { PAYMENT_TYPE, SPEND_TYPE, STATUS } from "@/utils/api.util";
 import { getReturnedQuantityMap, getSaleReturnItemKey } from "@/utils/saleReturn.util";
 import TenantContext from "@/lib/tenant-context";
 import { createTenantTransaction } from "@/lib/tenant-transaction";
+import { bumpInventorySequence } from "@/lib/inventory";
 
 const productSchema = Joi.object().keys({
   itemName: Joi.string().trim().required(),
@@ -82,6 +83,7 @@ const updateInventoryForReturn = async (products, transaction) => {
         },
         { transaction }
       );
+      await bumpInventorySequence(inventory.id, transaction);
     }
 
     updatedInventory.push(inventory);
@@ -236,4 +238,5 @@ const getLockOption = (transaction, model) => {
   return model ? { lock: { level: transaction.LOCK.UPDATE, of: model } } : { lock: transaction.LOCK.UPDATE };
 };
 
+export { updateInventoryForReturn };
 export default nextConnect({ onError }).use(auth).post(createSaleReturn).get(getAllSaleReturns);


### PR DESCRIPTION
## Summary

- `pages/api/purchase/approve/[id].js`'s `updateInventory()` and `pages/api/sales/returns/index.js`'s `updateInventoryForReturn()` both create a brand-new `Inventory` row with an **explicit id** (matching the product's own id) whenever no existing row matches `{ id, companyId, organizationId }`.
- Postgres sequences don't auto-advance when a primary key value is supplied explicitly, so `inventories_id_seq` silently drifted behind the real `MAX(id)` every time this ran for a genuinely new item.
- Confirmed as a **live, ongoing bug**, not just a one-time data-import artifact: restoring a June 29 2026 local Postgres backup on 2026-07-02 showed `inventories_id_seq` at 526 against a real `MAX(id)` of 1171 — drift that had already accumulated through normal app usage before the backup was even taken.
- Left unfixed, any future organic purchase approval that lets Postgres auto-assign an id would eventually collide with one of these already-taken explicit ids and crash with `duplicate key value violates unique constraint "inventories_pkey"` — the same failure mode already hit for `users_id_seq` on production Supabase (see #201's follow-up and `scripts/resync-tenant-sequences.js` from #205, which is a reactive patch, not a fix at the root — this PR is the root fix).

## Fix

Adds `lib/inventory.js`'s `bumpInventorySequence(id, transaction)`, called immediately after both `Inventory.create()` sites:

```sql
SELECT setval(
  pg_get_serial_sequence('inventories', 'id'),
  GREATEST(:id, (SELECT last_value FROM inventories_id_seq))
)
```

`GREATEST` means it only ever moves the sequence forward — a no-op if it's already ahead.

`updateInventoryForReturn` wasn't exported from `pages/api/sales/returns/index.js`, so it couldn't be unit tested directly. Exported it, matching the existing named-export pattern in `pages/api/purchase/approve/[id].js`.

## Test plan

- [x] Added regression tests to both route test files (`__tests__/api/purchase/approve.test.js`, `__tests__/api/sales/returns.test.js`) plus a direct unit test for the new helper (`__tests__/lib/inventory.test.js`)
- [x] Confirmed both route-level regression tests fail on the pre-fix code and pass with the fix (via temporary `git stash`)
- [x] Verified the actual SQL against real local Postgres: bumping forward when behind works, and calling it again with a smaller id correctly leaves the sequence untouched (`GREATEST` semantics)
- [x] `npx eslint` / `npx prettier --check` clean on all changed files
- [x] Full `npx jest` suite — no new failures (1 pre-existing unrelated failure in `navigation-config.test.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)